### PR TITLE
Add docker container and a serve.py app to serve the generate static files.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,118 @@
+node_modules
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode
+Makefile
+helm-charts
+.env
+.editorconfig
+.idea
+coverage*
+backup
+target
+target/**
+
+### Maven template
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+### Java template
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+__pycache__
+output

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ cheatsheets/*
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -242,3 +243,5 @@ tags
 [._]*.un~
 
 # End of https://www.toptal.com/developers/gitignore/api/Vim,macOS,Python,venv
+
+output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# using ubuntu LTS version
+FROM ubuntu:24.04 AS builder-image
+
+# avoid stuck build due to user prompt
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install --no-install-recommends -y python3 python3-dev python3-venv python3-pip python3-wheel build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# create and activate virtual environment
+# using final folder name to avoid path issues with packages
+RUN python3 -m venv /home/myuser/venv
+ENV PATH="/home/myuser/venv/bin:$PATH"
+
+# install requirements
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir wheel
+RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir gunicorn
+
+FROM ubuntu:24.04 AS runner-image
+RUN apt-get update && apt-get install --no-install-recommends -y python3 python3-venv && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home myuser
+USER myuser
+COPY --from=builder-image --chown=myuser:myuser /home/myuser/venv /home/myuser/venv
+
+RUN mkdir /home/myuser/code && mkdir /home/myuser/output && mkdir /home/myuser/code/cheatsheets
+WORKDIR /home/myuser/code
+COPY --chown=myuser:myuser . .
+RUN chmod +x docker/cmd.sh
+
+EXPOSE 5000
+
+# make sure all messages always reach console
+ENV PYTHONUNBUFFERED=1
+
+# activate virtual environment
+ENV VIRTUAL_ENV=/home/myuser/venv
+ENV PATH="/home/myuser/venv/bin:$PATH"
+ENV CHEATSHEET_OUTPUT_DIR="/home/myuser/output"
+
+# /dev/shm is mapped to shared memory and should be used for gunicorn heartbeat
+# this will improve performance and avoid random freezes
+# CMD ["gunicorn","-b", "0.0.0.0:5000", "-w", "4", "-k", "gevent", "--worker-tmp-dir", "/dev/shm", "app:app"]
+
+# CMD [ "python3", "src/generate_cheatsheet.py" ]
+CMD [ "docker/cmd.sh" ]

--- a/build.docker.sh
+++ b/build.docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker compose down
+rm -rf ./output/*
+
+# docker buildx build --platform linux/amd64,linux/arm64 --load --tag tobiashochguertel/koala-keys .
+docker buildx build --platform linux/amd64,linux/arm64 --push --load --tag tobiashochguertel/koala-keys .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  koala-keys:
+    image: tobiashochguertel/koala-keys
+    ports:
+      - "50505:5000"
+    volumes:
+      - ./cheatsheets:/home/myuser/code/cheatsheets
+      - ./output:/home/myuser/output

--- a/docker/cmd.sh
+++ b/docker/cmd.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+python3 src/generate_cheatsheet.py
+python3 src/serve.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pyyaml==6.0.2
 jinja2==3.1.4
 python-dotenv==1.0.1
 ruamel.yaml==0.18.6
+fastapi==0.115.4
+uvicorn==0.32.0

--- a/src/serve.py
+++ b/src/serve.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from logger import get_logger
+
+load_dotenv()
+
+# Define base paths
+BASE_DIR = Path(__file__).parent
+PROJECT_ROOT = BASE_DIR.parent
+
+# Define directory paths
+OUTPUT_DIR = Path(os.getenv("CHEATSHEET_OUTPUT_DIR") or PROJECT_ROOT / "output")
+
+logging = get_logger()
+
+app = FastAPI()
+
+logging.info(f"OUTPUT_DIR: {OUTPUT_DIR}")
+
+app.mount("/", StaticFiles(directory=f"{OUTPUT_DIR}", html=True))
+
+if __name__ == "__main__":
+
+    uvicorn.run("serve:app", host="0.0.0.0", port=5000, reload=True)


### PR DESCRIPTION
Adds Dockerfile and Compose file to the project.
Adds a simple static file html server via `fastapi` and `uvicorn`.

I pushed a Docker-image to Docker Hub (arm64, amd64): https://hub.docker.com/r/tobiashochguertel/koala-keys
the Docker-image generate the static html pages and then starts the simple html server to serve the generate content. Have a look into `docker-compose.yaml`.